### PR TITLE
Pacing fixes: remove adaptation penalty + hard pause on high-leverage results

### DIFF
--- a/src/components/InteractiveMatchView.tsx
+++ b/src/components/InteractiveMatchView.tsx
@@ -479,7 +479,10 @@ export function InteractiveMatchView({
       }
     }
 
-    if (newState.inningComplete || newState.isComplete) {
+    // Pause on high-leverage results: show the result and require explicit continue
+    // before auto-sim resumes. This gives the player a moment to absorb what happened.
+    const wasHighLeveragePlay = isHighLeverage(matchState);
+    if (newState.inningComplete || newState.isComplete || wasHighLeveragePlay) {
       setShowingResult(true);
     }
 

--- a/src/engine/constants.ts
+++ b/src/engine/constants.ts
@@ -295,11 +295,12 @@ export const GAME_CONSTANTS = {
     PITCH_HR_ALLOWED: -8,
   },
 
-  // Adaptation — penalizes consecutive same-approach/strategy use within a half-inning
+  // Adaptation — DISABLED (penalty scale removed)
+  // Previously penalized consecutive same-approach/strategy use, but this forced
+  // unnatural rotation and conflicted with strategic depth (e.g., wearing down a
+  // pitcher with "patient" approach). Now all approaches are equal weight.
   ADAPTATION: {
-    // Multiplier applied to stat modifiers: 1st use = full, then immediate diminishing returns
-    // Penalizes repetition from the 2nd use onward to make approach rotation meaningful
-    PENALTY_SCALE: [1.0, 0.85, 0.65, 0.40, 0.20] as readonly number[],
+    PENALTY_SCALE: [1.0, 1.0, 1.0, 1.0, 1.0] as readonly number[],
   },
 
   // AI Personality Presets - creates variation in AI behavior


### PR DESCRIPTION
## Summary

Two targeted fixes to improve interactive match pacing and feel.

### 1. Remove Adaptation Penalty

The `ADAPTATION.PENALTY_SCALE` was `[1.0, 0.85, 0.65, 0.40, 0.20]`, causing effectiveness to drop sharply when repeating the same approach. This penalized intentional strategy (e.g., wearing down a pitcher with repeated patient at-bats). Changed all values to `1.0` — repeated approaches are now a genuine strategic choice.

### 2. Hard Pause on High-Leverage Results

After a clutch at-bat resolved, the game immediately snapped back to auto-sim with no breathing room. Player would blink and miss the outcome, then suddenly get control back on the next high-leverage moment — jarring whiplash.

Now: any high-leverage at-bat (`isHighLeverage()` returns true) triggers `showingResult = true`, requiring an explicit "Continue" click before auto-sim resumes. Gives players time to absorb what just happened.

## Files Changed
- `src/engine/constants.ts` — ADAPTATION.PENALTY_SCALE all 1.0
- `src/components/InteractiveMatchView.tsx` — hard pause on high-leverage results